### PR TITLE
Verify if logfile is readable

### DIFF
--- a/dyndream.py
+++ b/dyndream.py
@@ -96,6 +96,10 @@ def main():
 
     if 'LOGFILE' in config:
         logfile = config['LOGFILE']
+        if not(os.access(logfile, os.W_OK)):
+            logfile = ''
+            print("Cannot open requested log file {}, logging to stdout"
+                  .format(logfile))
     else:
         logfile = ''
 


### PR DESCRIPTION
Very simple reliability fix: If the desired log file is not writable, write to STDOUT instead of throwing an exception.